### PR TITLE
Add mutable iterators

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ through:
   - Individual rows or columns (see [`row_iter`] and [`column_iter`]).
   - Individual rows and columns of mutable entries (see [`row_iter_mut`] and [`column_iter_mut`]).
   - All rows or all columns (see [`rows_iter`] and [`columns_iter`]).
-  - All rows or all columns of mutable entries (see [`rows_iter_mut`]).
+  - All rows or all columns of mutable entries (see [`rows_iter_mut`] and [`columns_iter_mut`]).
 
 
 ### Extracting all data from an [`Array2D`]
@@ -152,6 +152,7 @@ pub fn main() -> Result<(), Error> {
 [`rows_iter`]: struct.Array2D.html#method.rows_iter
 [`columns_iter`]: struct.Array2D.html#method.columns_iter
 [`rows_iter_mut`]: struct.Array2D.html#method.rows_iter_mut
+[`columns_iter_mut`]: struct.Array2D.html#method.columns_iter_mut
 [`as_rows`]: struct.Array2D.html#method.as_rows
 [`as_columns`]: struct.Array2D.html#method.as_columns
 [`as_row_major`]: struct.Array2D.html#method.as_row_major

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ through:
   - Individual rows or columns (see [`row_iter`] and [`column_iter`]).
   - Individual rows and columns of mutable entries (see [`row_iter_mut`] and [`column_iter_mut`]).
   - All rows or all columns (see [`rows_iter`] and [`columns_iter`]).
+  - All rows or all columns of mutable entries (see [`rows_iter_mut`]).
+
 
 ### Extracting all data from an [`Array2D`]
 
@@ -145,6 +147,7 @@ pub fn main() -> Result<(), Error> {
 [`column_iter_mut`]: struct.Array2D.html#method.column_iter_mut
 [`rows_iter`]: struct.Array2D.html#method.rows_iter
 [`columns_iter`]: struct.Array2D.html#method.columns_iter
+[`rows_iter_mut`]: struct.Array2D.html#method.rows_iter_mut
 [`as_rows`]: struct.Array2D.html#method.as_rows
 [`as_columns`]: struct.Array2D.html#method.as_columns
 [`as_row_major`]: struct.Array2D.html#method.as_row_major

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ An [`Array2D`] can be created in many different ways. These include:
 through:
   - All of the elements, in either [row major or column major order] (see
     [`elements_row_major_iter`] and [`elements_column_major_iter`]).
-  - Individual rows or columns (see [`row_iter`], [`row_iter_mut`] and [`column_iter`]).
+  - Individual rows or columns (see [`row_iter`] and [`column_iter`]).
+  - Individual rows and columns of mutable entries (see [`row_iter_mut`] and [`column_iter_mut`]).
   - All rows or all columns (see [`rows_iter`] and [`columns_iter`]).
 
 ### Extracting all data from an [`Array2D`]
@@ -139,8 +140,9 @@ pub fn main() -> Result<(), Error> {
 [`elements_row_major_iter`]: struct.Array2D.html#method.elements_row_major_iter
 [`elements_column_major_iter`]: struct.Array2D.html#method.elements_column_major_iter
 [`row_iter`]: struct.Array2D.html#method.row_iter
-[`row_iter_mut`]: struct.Array2D.html#method.row_iter_mut
 [`column_iter`]: struct.Array2D.html#method.column_iter
+[`row_iter_mut`]: struct.Array2D.html#method.row_iter_mut
+[`column_iter_mut`]: struct.Array2D.html#method.column_iter_mut
 [`rows_iter`]: struct.Array2D.html#method.rows_iter
 [`columns_iter`]: struct.Array2D.html#method.columns_iter
 [`as_rows`]: struct.Array2D.html#method.as_rows

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ An [`Array2D`] can be created in many different ways. These include:
 through:
   - All of the elements, in either [row major or column major order] (see
     [`elements_row_major_iter`] and [`elements_column_major_iter`]).
+  - All of the elements as mutable references, in [row major or column major order] (see
+    [`elements_row_major_iter_mut`]).
   - Individual rows or columns (see [`row_iter`] and [`column_iter`]).
   - Individual rows and columns of mutable entries (see [`row_iter_mut`] and [`column_iter_mut`]).
   - All rows or all columns (see [`rows_iter`] and [`columns_iter`]).
@@ -141,6 +143,7 @@ pub fn main() -> Result<(), Error> {
 [`set`]: struct.Array2D.html#method.set
 [`elements_row_major_iter`]: struct.Array2D.html#method.elements_row_major_iter
 [`elements_column_major_iter`]: struct.Array2D.html#method.elements_column_major_iter
+[`elements_row_major_iter_mut`]: struct.Array2D.html#method.elements_row_major_iter_mut
 [`row_iter`]: struct.Array2D.html#method.row_iter
 [`column_iter`]: struct.Array2D.html#method.column_iter
 [`row_iter_mut`]: struct.Array2D.html#method.row_iter_mut

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ An [`Array2D`] can be created in many different ways. These include:
 through:
   - All of the elements, in either [row major or column major order] (see
     [`elements_row_major_iter`] and [`elements_column_major_iter`]).
-  - Individual rows or columns (see [`row_iter`] and [`column_iter`]).
+  - Individual rows or columns (see [`row_iter`], [`row_iter_mut`] and [`column_iter`]).
   - All rows or all columns (see [`rows_iter`] and [`columns_iter`]).
 
 ### Extracting all data from an [`Array2D`]
@@ -139,6 +139,7 @@ pub fn main() -> Result<(), Error> {
 [`elements_row_major_iter`]: struct.Array2D.html#method.elements_row_major_iter
 [`elements_column_major_iter`]: struct.Array2D.html#method.elements_column_major_iter
 [`row_iter`]: struct.Array2D.html#method.row_iter
+[`row_iter_mut`]: struct.Array2D.html#method.row_iter_mut
 [`column_iter`]: struct.Array2D.html#method.column_iter
 [`rows_iter`]: struct.Array2D.html#method.rows_iter
 [`columns_iter`]: struct.Array2D.html#method.columns_iter

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ through:
   - All of the elements, in either [row major or column major order] (see
     [`elements_row_major_iter`] and [`elements_column_major_iter`]).
   - All of the elements as mutable references, in [row major or column major order] (see
-    [`elements_row_major_iter_mut`]).
+    [`elements_row_major_iter_mut`] and [`elements_column_major_iter_mut`]).
   - Individual rows or columns (see [`row_iter`] and [`column_iter`]).
   - Individual rows and columns of mutable entries (see [`row_iter_mut`] and [`column_iter_mut`]).
   - All rows or all columns (see [`rows_iter`] and [`columns_iter`]).
@@ -144,6 +144,7 @@ pub fn main() -> Result<(), Error> {
 [`elements_row_major_iter`]: struct.Array2D.html#method.elements_row_major_iter
 [`elements_column_major_iter`]: struct.Array2D.html#method.elements_column_major_iter
 [`elements_row_major_iter_mut`]: struct.Array2D.html#method.elements_row_major_iter_mut
+[`elements_column_major_iter_mut`]: struct.Array2D.html#method.elements_column_major_iter_mut
 [`row_iter`]: struct.Array2D.html#method.row_iter
 [`column_iter`]: struct.Array2D.html#method.column_iter
 [`row_iter_mut`]: struct.Array2D.html#method.row_iter_mut

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@
 //! through:
 //!   - All of the elements, in either [row major or column major order] (see
 //!     [`elements_row_major_iter`] and [`elements_column_major_iter`]).
+//!   - All of the elements as mutable references, in [row major or column major order] (see
+//!     [`elements_row_major_iter_mut`]).
 //!   - Individual rows or columns (see [`row_iter`] and [`column_iter`]).
 //!   - Individual rows and columns of mutable entries (see [`row_iter_mut`] and [`column_iter_mut`]).
 //!   - All rows or all columns (see [`rows_iter`] and [`columns_iter`]).
@@ -139,6 +141,7 @@
 //! [`set`]: struct.Array2D.html#method.set
 //! [`elements_row_major_iter`]: struct.Array2D.html#method.elements_row_major_iter
 //! [`elements_column_major_iter`]: struct.Array2D.html#method.elements_column_major_iter
+//! [`elements_row_major_iter_mut`]: struct.Array2D.html#method.elements_row_major_iter_mut
 //! [`row_iter`]: struct.Array2D.html#method.row_iter
 //! [`column_iter`]: struct.Array2D.html#method.column_iter
 //! [`rows_iter`]: struct.Array2D.html#method.rows_iter
@@ -815,6 +818,37 @@ impl<T> Array2D<T> {
     /// [row major order]: https://en.wikipedia.org/wiki/Row-_and_column-major_order
     pub fn elements_row_major_iter(&self) -> impl DoubleEndedIterator<Item = &T> {
         self.array.iter()
+    }
+
+    /// Returns an [`Iterator`] over mutable references to all elements in [row major
+    /// order].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use array2d::{Array2D, Error};
+    /// # fn main() -> Result<(), Error> {
+    ///    let rows = vec![vec![1, 2, 3], vec![4, 5, 6]];
+    ///    let elements = vec![1, 2, 3, 4, 5, 6];
+    ///    let mut array = Array2D::from_rows(&rows)?;
+    ///    let row_major = array.elements_row_major_iter_mut();
+    ///    for (i, val) in row_major
+    ///        .map(|val| {
+    ///            *val += 1;
+    ///            val
+    ///        })
+    ///        .enumerate()
+    ///    {
+    ///        assert_eq!(*val, elements[i] + 1);
+    ///    }
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`Iterator`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html
+    /// [row major order]: https://en.wikipedia.org/wiki/Row-_and_column-major_order
+    pub fn elements_row_major_iter_mut(&mut self) -> impl DoubleEndedIterator<Item = &mut T> {
+        self.array.iter_mut()
     }
 
     /// Returns an [`Iterator`] over references to all elements in [column major

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,9 @@
 //!   - All of the elements, in either [row major or column major order] (see
 //!     [`elements_row_major_iter`] and [`elements_column_major_iter`]).
 //!   - Individual rows or columns (see [`row_iter`] and [`column_iter`]).
+//!   - Individual rows and columns of mutable entries (see [`row_iter_mut`] and [`column_iter_mut`]).
 //!   - All rows or all columns (see [`rows_iter`] and [`columns_iter`]).
+//!
 //!
 //! ## Extracting all data from an [`Array2D`]
 //!
@@ -923,6 +925,39 @@ impl<T> Array2D<T> {
             return Err(Error::IndicesOutOfBounds(0, column_index));
         }
         Ok((0..self.column_len()).map(move |row_index| &self[(row_index, column_index)]))
+    }
+
+    /// Returns an [`Iterator`] over mutable references to all elements in the given
+    /// column. Returns an error if the index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use array2d::{Array2D, Error};
+    /// # fn main() -> Result<(), Error> {
+    /// let rows = vec![vec![1, 2, 3], vec![4, 5, 6]];
+    /// let mut array = Array2D::from_rows(&rows)?;
+    /// let mut column_iter = array.column_iter_mut(1)?;
+    /// assert_eq!(column_iter.next(), Some(&mut 2));
+    /// assert_eq!(column_iter.next(), Some(&mut 5));
+    /// assert_eq!(column_iter.next(), None);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`Iterator`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html
+    pub fn column_iter_mut(
+        &mut self,
+        column_index: usize,
+    ) -> Result<impl DoubleEndedIterator<Item = &mut T>, Error> {
+        if column_index >= self.num_columns {
+            return Err(Error::IndicesOutOfBounds(0, column_index));
+        }
+        Ok(self
+            .array
+            .iter_mut()
+            .skip(column_index)
+            .step_by(self.num_columns))
     }
 
     /// Returns an [`Iterator`] over all rows. Each [`Item`] is itself another

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1217,18 +1217,14 @@ impl<T> Array2D<T> {
     pub fn columns_iter_mut(
         &mut self,
     ) -> impl DoubleEndedIterator<Item = impl DoubleEndedIterator<Item = &mut T>> {
-        let (element_count, column_len, row_len) =
-            (self.num_elements(), self.column_len(), self.row_len());
+        let (num_columns, num_rows) = (self.num_columns(), self.num_rows());
         let pointer = self.array.as_mut_ptr();
-        self.array
-            .chunks_mut(column_len)
-            .enumerate()
-            .map(move |(ci, c)| {
-                c.iter_mut().enumerate().map(move |(i, _)| {
-                    let offset = (i * row_len) % element_count + ci;
-                    unsafe { &mut *pointer.add(offset) }
-                })
+        (0..num_columns).map(move |ci| {
+            (0..num_rows).map(move |i| {
+                let offset = (i * num_columns) + ci;
+                unsafe { &mut *pointer.add(offset) }
             })
+        })
     }
 
     /// Collects the [`Array2D`] into a [`Vec`] of rows, each of which contains

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -865,6 +865,37 @@ impl<T> Array2D<T> {
         Ok(self.array[start..end].iter())
     }
 
+    /// Returns an [`Iterator`] over mutable references to all elements in the given
+    /// row. Returns an error if the index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use array2d::{Array2D, Error};
+    /// # fn main() -> Result<(), Error> {
+    /// let rows = vec![vec![1, 2, 3], vec![4, 5, 6]];
+    /// let mut array = Array2D::from_rows(&rows)?;
+    /// let mut row_iter = array.row_iter_mut(1)?;
+    /// assert_eq!(row_iter.next(), Some(&mut 4));
+    /// assert_eq!(row_iter.next(), Some(&mut 5));
+    /// assert_eq!(row_iter.next(), Some(&mut 6));
+    /// assert_eq!(row_iter.next(), None);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`Iterator`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html
+    pub fn row_iter_mut(
+        &mut self,
+        row_index: usize,
+    ) -> Result<impl DoubleEndedIterator<Item = &mut T>, Error> {
+        let start = self
+            .get_index(row_index, 0)
+            .ok_or(Error::IndicesOutOfBounds(row_index, 0))?;
+        let end = start + self.row_len();
+        Ok(self.array[start..end].iter_mut())
+    }
+
     /// Returns an [`Iterator`] over references to all elements in the given
     /// column. Returns an error if the index is out of bounds.
     ///

--- a/tests/array2d.rs
+++ b/tests/array2d.rs
@@ -354,6 +354,23 @@ fn test_column_iter() -> Result<(), Error> {
 }
 
 #[test]
+fn test_column_iter_mut() -> Result<(), Error> {
+    let rows = vec![vec![1, 2, 3], vec![4, 5, 6]];
+    let mut array = Array2D::from_rows(&rows)?;
+    let first_column_iter = array.column_iter_mut(0)?;
+    for (index, element) in first_column_iter.enumerate() {
+        *element += 1;
+        assert_eq!(*element, &rows[index][0] + 1);
+    }
+    let second_column_iter = array.column_iter_mut(1)?;
+    for (index, element) in second_column_iter.enumerate() {
+        *element += 1;
+        assert_eq!(*element, &rows[index][1] + 1);
+    }
+    Ok(())
+}
+
+#[test]
 fn test_rows_iter() -> Result<(), Error> {
     let rows = vec![vec![1, 2, 3], vec![4, 5, 6]];
     let array = Array2D::from_rows(&rows)?;

--- a/tests/array2d.rs
+++ b/tests/array2d.rs
@@ -322,6 +322,23 @@ fn test_row_iter() -> Result<(), Error> {
 }
 
 #[test]
+fn test_row_iter_mut() -> Result<(), Error> {
+    let rows = vec![vec![1, 2, 3], vec![4, 5, 6]];
+    let mut array = Array2D::from_rows(&rows)?;
+    let first_row_iter = array.row_iter_mut(0)?;
+    for (index, element) in first_row_iter.enumerate() {
+        *element += 1;
+        assert_eq!(*element, &rows[0][index] + 1);
+    }
+    let second_row_iter = array.row_iter_mut(1)?;
+    for (index, element) in second_row_iter.enumerate() {
+        *element += 1;
+        assert_eq!(*element, &rows[1][index] + 1);
+    }
+    Ok(())
+}
+
+#[test]
 fn test_column_iter() -> Result<(), Error> {
     let rows = vec![vec![1, 2, 3], vec![4, 5, 6]];
     let array = Array2D::from_rows(&rows)?;

--- a/tests/array2d.rs
+++ b/tests/array2d.rs
@@ -442,6 +442,19 @@ fn test_columns_iter() -> Result<(), Error> {
 }
 
 #[test]
+fn test_columns_iter_mut() -> Result<(), Error> {
+    let rows = vec![vec![1, 2, 3], vec![4, 5, 6]];
+    let mut array = Array2D::from_rows(&rows)?;
+    for (column_index, column_iter) in array.columns_iter_mut().enumerate() {
+        for (row_index, element) in column_iter.enumerate() {
+            *element += 1;
+            assert_eq!(*element, &rows[row_index][column_index] + 1);
+        }
+    }
+    Ok(())
+}
+
+#[test]
 fn test_op_index() -> Result<(), Error> {
     let rows = vec![vec![1, 2, 3], vec![4, 5, 6]];
     let array = Array2D::from_rows(&rows)?;

--- a/tests/array2d.rs
+++ b/tests/array2d.rs
@@ -383,6 +383,19 @@ fn test_rows_iter() -> Result<(), Error> {
 }
 
 #[test]
+fn test_rows_iter_mut() -> Result<(), Error> {
+    let rows = vec![vec![1, 2, 3], vec![4, 5, 6]];
+    let mut array = Array2D::from_rows(&rows)?;
+    for (row_index, row_iter) in array.rows_iter_mut().enumerate() {
+        for (column_index, element) in row_iter.enumerate() {
+            *element += 1;
+            assert_eq!(*element, &rows[row_index][column_index] + 1);
+        }
+    }
+    Ok(())
+}
+
+#[test]
 fn test_columns_iter() -> Result<(), Error> {
     let rows = vec![vec![1, 2, 3], vec![4, 5, 6]];
     let array = Array2D::from_rows(&rows)?;

--- a/tests/array2d.rs
+++ b/tests/array2d.rs
@@ -324,6 +324,23 @@ fn test_elements_column_major_iter() -> Result<(), Error> {
 }
 
 #[test]
+fn test_elements_column_major_iter_mut() -> Result<(), Error> {
+    let rows = vec![vec![1, 2, 3], vec![4, 5, 6]];
+    let column_major = vec![1, 4, 2, 5, 3, 6];
+    let mut array = Array2D::from_rows(&rows)?;
+    let column_len = rows.len();
+    for (index, element) in array.elements_column_major_iter_mut().enumerate() {
+        let column_index = index / column_len;
+        let row_index = index % column_len;
+        // Do it both ways to make sure we're doing this right
+        *element += 1;
+        assert_eq!(*element, &rows[row_index][column_index] + 1);
+        assert_eq!(*element, &column_major[index] + 1);
+    }
+    Ok(())
+}
+
+#[test]
 fn test_row_iter() -> Result<(), Error> {
     let rows = vec![vec![1, 2, 3], vec![4, 5, 6]];
     let array = Array2D::from_rows(&rows)?;

--- a/tests/array2d.rs
+++ b/tests/array2d.rs
@@ -291,6 +291,23 @@ fn test_elements_row_major_iter() -> Result<(), Error> {
 }
 
 #[test]
+fn test_elements_row_major_iter_mut() -> Result<(), Error> {
+    let rows = vec![vec![1, 2, 3], vec![4, 5, 6]];
+    let row_major = vec![1, 2, 3, 4, 5, 6];
+    let mut array = Array2D::from_rows(&rows)?;
+    let row_len = rows[0].len();
+    for (index, element) in array.elements_row_major_iter_mut().enumerate() {
+        let row_index = index / row_len;
+        let column_index = index % row_len;
+        // Do it both ways to make sure we're doing this right
+        *element += 1;
+        assert_eq!(*element, &rows[row_index][column_index] + 1);
+        assert_eq!(*element, &row_major[index] + 1);
+    }
+    Ok(())
+}
+
+#[test]
 fn test_elements_column_major_iter() -> Result<(), Error> {
     let rows = vec![vec![1, 2, 3], vec![4, 5, 6]];
     let column_major = vec![1, 4, 2, 5, 3, 6];


### PR DESCRIPTION
fixes #6

- [x] `row_iter_mut` 
- [x] `column_iter_mut`
- [x] `rows_iter_mut`
- [x] `columns_iter_mut`
- [x] `elements_row_major_iter_mut`
- [x] `elements_column_major_iter_mut`

I've decided to attempt to contribute these functions myself :) They rely on one usage of an unsafe pointer the for the columns iter. (`elements_column_major_iter_mut` relies on `columns_iter_mut`; In `columns_iter_mut` we're using an unsafe pointer to grab the value that we need when we need it mutable)

The rest of the functions are safe. There is an alternative way to implement the columns iter safely, but that'd require actually shuffling the internal data around and resetting it when the iterator is dropped, or allocating a new array for the data, unsafe seemed like the best option!