### PR TITLE
Implement Clone for all iterators

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -814,7 +814,7 @@ impl<T> Array2D<T> {
     ///
     /// [`Iterator`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html
     /// [row major order]: https://en.wikipedia.org/wiki/Row-_and_column-major_order
-    pub fn elements_row_major_iter(&self) -> impl DoubleEndedIterator<Item = &T> {
+    pub fn elements_row_major_iter(&self) -> impl DoubleEndedIterator<Item = &T> + Clone {
         self.array.iter()
     }
 
@@ -837,7 +837,7 @@ impl<T> Array2D<T> {
     ///
     /// [`Iterator`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html
     /// [column major order]: https://en.wikipedia.org/wiki/Row-_and_column-major_order
-    pub fn elements_column_major_iter(&self) -> impl DoubleEndedIterator<Item = &T> {
+    pub fn elements_column_major_iter(&self) -> impl DoubleEndedIterator<Item = &T> + Clone {
         self.indices_column_major().map(move |i| &self[i])
     }
 
@@ -938,7 +938,7 @@ impl<T> Array2D<T> {
     /// [`Item`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#associatedtype.Item
     pub fn rows_iter(
         &self,
-    ) -> impl DoubleEndedIterator<Item = impl DoubleEndedIterator<Item = &T>> {
+    ) -> impl DoubleEndedIterator<Item = impl DoubleEndedIterator<Item = &T>> + Clone {
         (0..self.num_rows()).map(move |row_index| {
             self.row_iter(row_index)
                 .expect("rows_iter should never fail")
@@ -988,7 +988,7 @@ impl<T> Array2D<T> {
     /// [`Item`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#associatedtype.Item
     pub fn columns_iter(
         &self,
-    ) -> impl DoubleEndedIterator<Item = impl DoubleEndedIterator<Item = &T>> {
+    ) -> impl DoubleEndedIterator<Item = impl DoubleEndedIterator<Item = &T>> + Clone {
         (0..self.num_columns).map(move |column_index| {
             self.column_iter(column_index)
                 .expect("columns_iter should never fail")
@@ -1116,7 +1116,7 @@ impl<T> Array2D<T> {
     /// ```
     ///
     /// [`usize`]: https://doc.rust-lang.org/std/primitive.usize.html
-    pub fn indices_row_major(&self) -> impl DoubleEndedIterator<Item = (usize, usize)> {
+    pub fn indices_row_major(&self) -> impl DoubleEndedIterator<Item = (usize, usize)> + Clone {
         indices_row_major(self.num_rows, self.num_columns)
     }
 
@@ -1139,7 +1139,7 @@ impl<T> Array2D<T> {
     /// ```
     ///
     /// [`usize`]: https://doc.rust-lang.org/std/primitive.usize.html
-    pub fn indices_column_major(&self) -> impl DoubleEndedIterator<Item = (usize, usize)> {
+    pub fn indices_column_major(&self) -> impl DoubleEndedIterator<Item = (usize, usize)> + Clone {
         indices_column_major(self.num_rows, self.num_columns)
     }
 
@@ -1167,7 +1167,7 @@ impl<T> Array2D<T> {
     /// # }
     ///
     /// [`usize`]: https://doc.rust-lang.org/std/primitive.usize.html
-    pub fn enumerate_row_major(&self) -> impl DoubleEndedIterator<Item = ((usize, usize), &T)> {
+    pub fn enumerate_row_major(&self) -> impl DoubleEndedIterator<Item = ((usize, usize), &T)> + Clone {
         self.indices_row_major().map(move |i| (i, &self[i]))
     }
 
@@ -1195,7 +1195,7 @@ impl<T> Array2D<T> {
     /// # }
     ///
     /// [`usize`]: https://doc.rust-lang.org/std/primitive.usize.html
-    pub fn enumerate_column_major(&self) -> impl DoubleEndedIterator<Item = ((usize, usize), &T)> {
+    pub fn enumerate_column_major(&self) -> impl DoubleEndedIterator<Item = ((usize, usize), &T)> + Clone {
         self.indices_column_major().map(move |i| (i, &self[i]))
     }
 
@@ -1271,13 +1271,13 @@ fn flatten<T: Clone>(nested: &[Vec<T>]) -> Vec<T> {
 fn indices_row_major(
     num_rows: usize,
     num_columns: usize,
-) -> impl DoubleEndedIterator<Item = (usize, usize)> {
+) -> impl DoubleEndedIterator<Item = (usize, usize)> + Clone {
     (0..num_rows).flat_map(move |row| (0..num_columns).map(move |column| (row, column)))
 }
 
 fn indices_column_major(
     num_rows: usize,
     num_columns: usize,
-) -> impl DoubleEndedIterator<Item = (usize, usize)> {
+) -> impl DoubleEndedIterator<Item = (usize, usize)> + Clone {
     (0..num_columns).flat_map(move |column| (0..num_rows).map(move |row| (row, column)))
 }


### PR DESCRIPTION
Add an additional `impl Clone` constraint to all iterators returned from `Array2D` methods.

Closes #3

I implemented this in a new branch because several methods were added since #3 was submitted. Thank you to @nihilox for the suggestion!