### PR TITLE
Put dimension parameters first

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 //!
 //! pub fn main() -> Result<(), Error> {
 //!     // Create an array filled with the same element.
-//!     let prefilled = Array2D::filled_with(42, 2, 3);
+//!     let prefilled = Array2D::filled_with(2, 3, 42);
 //!     assert_eq!(prefilled.num_rows(), 2);
 //!     assert_eq!(prefilled.num_columns(), 3);
 //!     assert_eq!(prefilled[(0, 0)], 42);
@@ -77,7 +77,7 @@
 //!     // column major order.
 //!     let column_major = vec![1, 4, 2, 5, 3, 6];
 //!     let from_column_major =
-//!         Array2D::from_column_major(&column_major, 2, 3)?;
+//!         Array2D::from_column_major(2, 3, &column_major)?;
 //!     assert_eq!(from_column_major.num_rows(), 2);
 //!     assert_eq!(from_column_major.num_columns(), 3);
 //!     assert_eq!(from_column_major[(1, 1)], 5);
@@ -289,7 +289,7 @@ impl<T> Array2D<T> {
     /// # use array2d::{Array2D, Error};
     /// # fn main() -> Result<(), Error> {
     /// let row_major = vec![1, 2, 3, 4, 5, 6];
-    /// let array = Array2D::from_row_major(&row_major, 2, 3)?;
+    /// let array = Array2D::from_row_major(2, 3, &row_major)?;
     /// assert_eq!(array[(1, 2)], 6);
     /// assert_eq!(array.as_rows(), vec![vec![1, 2, 3], vec![4, 5, 6]]);
     /// # Ok(())
@@ -299,9 +299,9 @@ impl<T> Array2D<T> {
     /// [`Array2D`]: struct.Array2D.html
     /// [row major order]: https://en.wikipedia.org/wiki/Row-_and_column-major_order
     pub fn from_row_major(
-        elements: &[T],
         num_rows: usize,
         num_columns: usize,
+        elements: &[T],
     ) -> Result<Self, Error>
     where
         T: Clone,
@@ -330,7 +330,7 @@ impl<T> Array2D<T> {
     /// # use array2d::{Array2D, Error};
     /// # fn main() -> Result<(), Error> {
     /// let column_major = vec![1, 4, 2, 5, 3, 6];
-    /// let array = Array2D::from_column_major(&column_major, 2, 3)?;
+    /// let array = Array2D::from_column_major(2, 3, &column_major)?;
     /// assert_eq!(array[(1, 2)], 6);
     /// assert_eq!(array.as_rows(), vec![vec![1, 2, 3], vec![4, 5, 6]]);
     /// # Ok(())
@@ -340,9 +340,9 @@ impl<T> Array2D<T> {
     /// [`Array2D`]: struct.Array2D.html
     /// [column major order]: https://en.wikipedia.org/wiki/Row-_and_column-major_order
     pub fn from_column_major(
-        elements: &[T],
         num_rows: usize,
         num_columns: usize,
+        elements: &[T],
     ) -> Result<Self, Error>
     where
         T: Clone,
@@ -373,12 +373,12 @@ impl<T> Array2D<T> {
     ///
     /// ```
     /// # use array2d::{Array2D, Error};
-    /// let array = Array2D::filled_with(42, 2, 3);
+    /// let array = Array2D::filled_with(2, 3, 42);
     /// assert_eq!(array.as_rows(), vec![vec![42, 42, 42], vec![42, 42, 42]]);
     /// ```
     ///
     /// [`Array2D`]: struct.Array2D.html
-    pub fn filled_with(element: T, num_rows: usize, num_columns: usize) -> Self
+    pub fn filled_with(num_rows: usize, num_columns: usize, element: T) -> Self
     where
         T: Clone,
     {
@@ -397,7 +397,7 @@ impl<T> Array2D<T> {
     where
         T: Clone,
     {
-        Array2D::filled_with(element, num_rows, num_columns)
+        Array2D::filled_with(num_rows, num_columns, element)
     }
 
     /// Creates a new [`Array2D`] with the specified number of rows and columns
@@ -415,12 +415,12 @@ impl<T> Array2D<T> {
     ///     counter += 1;
     ///     tmp
     /// };
-    /// let array = Array2D::filled_by_row_major(increment, 2, 3);
+    /// let array = Array2D::filled_by_row_major(2, 3, increment);
     /// assert_eq!(array.as_rows(), vec![vec![1, 2, 3], vec![4, 5, 6]]);
     /// ```
     ///
     /// [`Array2D`]: struct.Array2D.html
-    pub fn filled_by_row_major<F>(mut generator: F, num_rows: usize, num_columns: usize) -> Self
+    pub fn filled_by_row_major<F>(num_rows: usize, num_columns: usize, mut generator: F) -> Self
     where
         F: FnMut() -> T,
     {
@@ -448,19 +448,19 @@ impl<T> Array2D<T> {
     ///     counter += 1;
     ///     tmp
     /// };
-    /// let array = Array2D::filled_by_column_major(increment, 2, 3);
+    /// let array = Array2D::filled_by_column_major(2, 3, increment);
     /// assert_eq!(array.as_columns(), vec![vec![1, 2], vec![3, 4], vec![5, 6]]);
     /// ```
     ///
     /// [`Array2D`]: struct.Array2D.html
-    pub fn filled_by_column_major<F>(mut generator: F, num_rows: usize, num_columns: usize) -> Self
+    pub fn filled_by_column_major<F>(num_rows: usize, num_columns: usize, mut generator: F) -> Self
     where
         F: FnMut() -> T,
         T: Clone,
     {
         let total_len = num_rows * num_columns;
         let array_column_major = (0..total_len).map(|_| generator()).collect::<Vec<_>>();
-        Array2D::from_column_major(&array_column_major, num_rows, num_columns)
+        Array2D::from_column_major(num_rows, num_columns, &array_column_major)
             .expect("Filled by should never fail")
     }
 
@@ -478,7 +478,7 @@ impl<T> Array2D<T> {
     /// # use array2d::{Array2D, Error};
     /// # fn main() -> Result<(), Error> {
     /// let iterator = 1..;
-    /// let array = Array2D::from_iter_row_major(iterator, 2, 3)?;
+    /// let array = Array2D::from_iter_row_major(2, 3, iterator)?;
     /// assert_eq!(array.as_rows(), vec![vec![1, 2, 3], vec![4, 5, 6]]);
     /// # Ok(())
     /// # }
@@ -487,9 +487,9 @@ impl<T> Array2D<T> {
     /// [`Array2D`]: struct.Array2D.html
     /// [row major order]: https://en.wikipedia.org/wiki/Row-_and_column-major_order
     pub fn from_iter_row_major<I>(
-        iterator: I,
         num_rows: usize,
         num_columns: usize,
+        iterator: I,
     ) -> Result<Self, Error>
     where
         I: Iterator<Item = T>,
@@ -520,7 +520,7 @@ impl<T> Array2D<T> {
     /// # use array2d::{Array2D, Error};
     /// # fn main() -> Result<(), Error> {
     /// let iterator = 1..;
-    /// let array = Array2D::from_iter_column_major(iterator, 2, 3)?;
+    /// let array = Array2D::from_iter_column_major(2, 3, iterator)?;
     /// assert_eq!(array.as_rows(), vec![vec![1, 3, 5], vec![2, 4, 6]]);
     /// # Ok(())
     /// # }
@@ -529,9 +529,9 @@ impl<T> Array2D<T> {
     /// [`Array2D`]: struct.Array2D.html
     /// [column major order]: https://en.wikipedia.org/wiki/Row-_and_column-major_order
     pub fn from_iter_column_major<I>(
-        iterator: I,
         num_rows: usize,
         num_columns: usize,
+        iterator: I,
     ) -> Result<Self, Error>
     where
         I: Iterator<Item = T>,
@@ -539,7 +539,7 @@ impl<T> Array2D<T> {
     {
         let total_len = num_rows * num_columns;
         let array_column_major = iterator.take(total_len).collect::<Vec<_>>();
-        Array2D::from_column_major(&array_column_major, num_rows, num_columns)
+        Array2D::from_column_major(num_rows, num_columns, &array_column_major)
             .map_err(|_| Error::NotEnoughElements)
     }
 
@@ -577,7 +577,7 @@ impl<T> Array2D<T> {
     ///
     /// ```
     /// # use array2d::{Array2D, Error};
-    /// let array = Array2D::filled_with(42, 2, 3);
+    /// let array = Array2D::filled_with(2, 3, 42);
     /// assert_eq!(array.get(0, 0), Some(&42));
     /// assert_eq!(array.get(10, 10), None);
     /// ```
@@ -642,7 +642,7 @@ impl<T> Array2D<T> {
     ///
     /// ```
     /// # use array2d::{Array2D, Error};
-    /// let mut array = Array2D::filled_with(42, 2, 3);
+    /// let mut array = Array2D::filled_with(2, 3, 42);
     ///
     /// assert_eq!(array.get_mut(0, 0), Some(&mut 42));
     /// assert_eq!(array.get_mut(10, 10), None);
@@ -727,7 +727,7 @@ impl<T> Array2D<T> {
     ///
     /// ```
     /// # use array2d::{Array2D, Error};
-    /// let mut array = Array2D::filled_with(42, 2, 3);
+    /// let mut array = Array2D::filled_with(2, 3, 42);
     ///
     /// let result = array.set(0, 0, 100);
     /// assert_eq!(result, Ok(()));
@@ -757,7 +757,7 @@ impl<T> Array2D<T> {
     ///
     /// ```
     /// # use array2d::{Array2D, Error};
-    /// let mut array = Array2D::filled_with(42, 2, 3);
+    /// let mut array = Array2D::filled_with(2, 3, 42);
     ///
     /// let result = array.set_row_major(4, 100);
     /// assert_eq!(result, Ok(()));
@@ -787,7 +787,7 @@ impl<T> Array2D<T> {
     ///
     /// ```
     /// # use array2d::{Array2D, Error};
-    /// let mut array = Array2D::filled_with(42, 2, 3);
+    /// let mut array = Array2D::filled_with(2, 3, 42);
     ///
     /// let result = array.set_column_major(4, 100);
     /// assert_eq!(result, Ok(()));
@@ -1241,7 +1241,7 @@ impl<T> Index<(usize, usize)> for Array2D<T> {
     ///
     /// ```
     /// # use array2d::{Array2D, Error};
-    /// let array = Array2D::filled_with(42, 2, 3);
+    /// let array = Array2D::filled_with(2, 3, 42);
     /// assert_eq!(array[(0, 0)], 42);
     /// ```
     ///
@@ -1251,7 +1251,7 @@ impl<T> Index<(usize, usize)> for Array2D<T> {
     ///
     /// ```rust,should_panic
     /// # use array2d::Array2D;
-    /// let array = Array2D::filled_with(42, 2, 3);
+    /// let array = Array2D::filled_with(2, 3, 42);
     /// let element = array[(10, 10)];
     /// ```
     fn index(&self, (row, column): (usize, usize)) -> &Self::Output {
@@ -1268,7 +1268,7 @@ impl<T> IndexMut<(usize, usize)> for Array2D<T> {
     ///
     /// ```
     /// # use array2d::{Array2D, Error};
-    /// let mut array = Array2D::filled_with(42, 2, 3);
+    /// let mut array = Array2D::filled_with(2, 3, 42);
     /// array[(0, 0)] = 100;
     /// assert_eq!(array[(0, 0)], 100);
     /// ```
@@ -1279,7 +1279,7 @@ impl<T> IndexMut<(usize, usize)> for Array2D<T> {
     ///
     /// ```rust,should_panic
     /// # use array2d::Array2D;
-    /// let mut array = Array2D::filled_with(42, 2, 3);
+    /// let mut array = Array2D::filled_with(2, 3, 42);
     /// array[(10, 10)] = 7;
     /// ```
     fn index_mut(&mut self, (row, column): (usize, usize)) -> &mut Self::Output {

--- a/tests/array2d.rs
+++ b/tests/array2d.rs
@@ -26,7 +26,7 @@ fn test_from_row_major() -> Result<(), Error> {
     let row_major = vec![1, 2, 3, 4, 5, 6];
     let num_rows = 2;
     let num_columns = 3;
-    let array = Array2D::from_row_major(&row_major, num_rows, num_columns)?;
+    let array = Array2D::from_row_major(num_rows, num_columns, &row_major)?;
     for (row_index, row) in rows.iter().enumerate() {
         for (column_index, element) in row.iter().enumerate() {
             assert_eq!(array.get(row_index, column_index), Some(element));
@@ -41,7 +41,7 @@ fn test_from_column_major() -> Result<(), Error> {
     let column_major = vec![1, 4, 2, 5, 3, 6];
     let num_rows = 2;
     let num_columns = 3;
-    let array = Array2D::from_column_major(&column_major, num_rows, num_columns)?;
+    let array = Array2D::from_column_major(num_rows, num_columns, &column_major)?;
     for (row_index, row) in rows.iter().enumerate() {
         for (column_index, element) in row.iter().enumerate() {
             assert_eq!(array.get(row_index, column_index), Some(element));
@@ -53,7 +53,7 @@ fn test_from_column_major() -> Result<(), Error> {
 #[test]
 fn test_filled_with() -> Result<(), Error> {
     let element = 7;
-    let array = Array2D::filled_with(element, 4, 5);
+    let array = Array2D::filled_with(4, 5, element);
     assert_eq!(array.num_rows(), 4);
     assert_eq!(array.num_columns(), 5);
     assert_eq!(array.num_elements(), 20);
@@ -74,7 +74,7 @@ fn test_filled_by_row_major() -> Result<(), Error> {
         counter += 1;
         tmp
     };
-    let array = Array2D::filled_by_row_major(increment, 2, 3);
+    let array = Array2D::filled_by_row_major(2, 3, increment);
     assert_eq!(array.as_rows(), vec![vec![1, 2, 3], vec![4, 5, 6]]);
     Ok(())
 }
@@ -87,21 +87,21 @@ fn test_filled_by_column_major() -> Result<(), Error> {
         counter += 1;
         tmp
     };
-    let array = Array2D::filled_by_column_major(increment, 2, 3);
+    let array = Array2D::filled_by_column_major(2, 3, increment);
     assert_eq!(array.as_columns(), vec![vec![1, 2], vec![3, 4], vec![5, 6]]);
     Ok(())
 }
 
 #[test]
 fn test_from_iter_row_major() -> Result<(), Error> {
-    let array = Array2D::from_iter_row_major(1.., 2, 3)?;
+    let array = Array2D::from_iter_row_major(2, 3, 1..)?;
     assert_eq!(array.as_rows(), vec![vec![1, 2, 3], vec![4, 5, 6]]);
     Ok(())
 }
 
 #[test]
 fn test_from_iter_column_major() -> Result<(), Error> {
-    let array = Array2D::from_iter_column_major(1.., 2, 3)?;
+    let array = Array2D::from_iter_column_major(2, 3, 1..)?;
     assert_eq!(array.as_columns(), vec![vec![1, 2], vec![3, 4], vec![5, 6]]);
     Ok(())
 }
@@ -408,7 +408,7 @@ fn test_from_row_major_dimensions_do_not_match_size() {
     let row_major = vec![1, 2, 3, 4, 5, 6, 7];
     let num_rows = 2;
     let num_columns = 3;
-    let result = Array2D::from_row_major(&row_major, num_rows, num_columns);
+    let result = Array2D::from_row_major(num_rows, num_columns, &row_major);
     assert_eq!(result, Err(Error::DimensionMismatch));
 }
 
@@ -417,7 +417,7 @@ fn test_from_column_major_dimensions_do_not_match_size() {
     let column_major = vec![1, 4, 2, 5, 3];
     let num_rows = 2;
     let num_columns = 3;
-    let result = Array2D::from_column_major(&column_major, num_rows, num_columns);
+    let result = Array2D::from_column_major(num_rows, num_columns, &column_major);
     assert_eq!(result, Err(Error::DimensionMismatch));
 }
 
@@ -426,7 +426,7 @@ fn test_from_iter_row_major_not_enough() {
     let iter = 1..5;
     let num_rows = 2;
     let num_columns = 3;
-    let result = Array2D::from_iter_row_major(iter, num_rows, num_columns);
+    let result = Array2D::from_iter_row_major(num_rows, num_columns, iter);
     assert_eq!(result, Err(Error::NotEnoughElements));
 }
 
@@ -435,7 +435,7 @@ fn test_from_iter_column_major_not_enough() {
     let iter = 1..5;
     let num_rows = 2;
     let num_columns = 3;
-    let result = Array2D::from_iter_column_major(iter, num_rows, num_columns);
+    let result = Array2D::from_iter_column_major(num_rows, num_columns, iter);
     assert_eq!(result, Err(Error::NotEnoughElements));
 }
 
@@ -444,7 +444,7 @@ fn test_row_iter_out_of_bounds() {
     let element = 42;
     let num_rows = 2;
     let num_columns = 3;
-    let array = Array2D::filled_with(element, num_rows, num_columns);
+    let array = Array2D::filled_with(num_rows, num_columns, element);
     let result = array.row_iter(num_rows);
     assert!(result.is_err());
 }
@@ -454,7 +454,7 @@ fn test_column_iter_out_of_bounds() {
     let element = 42;
     let num_rows = 2;
     let num_columns = 3;
-    let array = Array2D::filled_with(element, num_rows, num_columns);
+    let array = Array2D::filled_with(num_rows, num_columns, element);
     let result = array.column_iter(num_columns);
     assert!(result.is_err());
 }
@@ -465,7 +465,7 @@ fn test_index_out_of_bounds_row() {
     let element = 42;
     let num_rows = 2;
     let num_columns = 3;
-    let array = Array2D::filled_with(element, num_rows, num_columns);
+    let array = Array2D::filled_with(num_rows, num_columns, element);
     let _ = array[(num_rows, 0)];
 }
 
@@ -475,7 +475,7 @@ fn test_index_out_of_bounds_column() {
     let element = 42;
     let num_rows = 2;
     let num_columns = 3;
-    let array = Array2D::filled_with(element, num_rows, num_columns);
+    let array = Array2D::filled_with(num_rows, num_columns, element);
     let _ = array[(0, num_columns)];
 }
 
@@ -485,7 +485,7 @@ fn test_index_out_of_bounds_row_and_column() {
     let element = 42;
     let num_rows = 2;
     let num_columns = 3;
-    let array = Array2D::filled_with(element, num_rows, num_columns);
+    let array = Array2D::filled_with(num_rows, num_columns, element);
     let _ = array[(num_rows, num_columns)];
 }
 
@@ -495,7 +495,7 @@ fn test_index_mut_out_of_bounds_row() {
     let element = 42;
     let num_rows = 2;
     let num_columns = 3;
-    let mut array = Array2D::filled_with(element, num_rows, num_columns);
+    let mut array = Array2D::filled_with(num_rows, num_columns, element);
     array[(num_rows, 0)] += 1;
 }
 
@@ -505,7 +505,7 @@ fn test_index_mut_out_of_bounds_column() {
     let element = 42;
     let num_rows = 2;
     let num_columns = 3;
-    let mut array = Array2D::filled_with(element, num_rows, num_columns);
+    let mut array = Array2D::filled_with(num_rows, num_columns, element);
     array[(0, num_columns)] += 1;
 }
 
@@ -515,7 +515,7 @@ fn test_index_mut_out_of_bounds_row_and_column() {
     let element = 42;
     let num_rows = 2;
     let num_columns = 3;
-    let mut array = Array2D::filled_with(element, num_rows, num_columns);
+    let mut array = Array2D::filled_with(num_rows, num_columns, element);
     array[(num_rows, num_columns)] += 1;
 }
 
@@ -537,7 +537,7 @@ fn test_empty_array_from_rows() -> Result<(), Error> {
 #[test]
 fn test_empty_array_from_row_major() -> Result<(), Error> {
     let row_major: Vec<i32> = vec![];
-    let array = Array2D::from_row_major(&row_major, 0, 0)?;
+    let array = Array2D::from_row_major(0, 0, &row_major)?;
     assert_eq!(array.num_rows(), 0);
     assert_eq!(array.num_columns(), 0);
     assert_eq!(array.row_len(), 0);
@@ -559,7 +559,7 @@ fn test_empty_array_from_rows_many_empty_rows() -> Result<(), Error> {
 #[test]
 fn test_empty_array_from_row_major_non_zero_columns() -> Result<(), Error> {
     let row_major: Vec<i32> = vec![];
-    let array = Array2D::from_row_major(&row_major, 0, 4)?;
+    let array = Array2D::from_row_major(0, 4, &row_major)?;
     assert_eq!(array.num_rows(), 0);
     assert_eq!(array.num_columns(), 4);
     assert_eq!(array.row_len(), 4);


### PR DESCRIPTION
There are several methods that can be used to create a new `Array2D`. In the past, these have typically had the "source" (iterator, generator function, etc.) first, followed by the dimensions. However, this can make the source code somewhat awkward if, for example, you use a closure that ends up being moderately large. These functions now put the dimensions first, which makes the "source" parameter last.