### PR TITLE
add bevy_reflect Reflect derive behind a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ repository = "https://github.com/HarrisonMc555/array2d"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }
+bevy_reflect = { version = "0.14.2", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,10 +162,13 @@ use std::ops::{Index, IndexMut};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::Reflect;
 
 /// A fixed sized two-dimensional array.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 pub struct Array2D<T> {
     array: Vec<T>,
     num_rows: usize,


### PR DESCRIPTION
I have been using this in a bevy project, will be handy to be able to derive Reflect on structs containing this type. I've implemented this the same way as the Serde derive with an optional feature.